### PR TITLE
feat(matters): admin-only Stop/Archive (#70) + Restart stopped matters (#71)

### DIFF
--- a/Portal/e2e/stop-workflow.spec.ts
+++ b/Portal/e2e/stop-workflow.spec.ts
@@ -2,9 +2,15 @@ import { test, expect } from './fixtures';
 import { createMatter, deleteMatter, getMatter, currentStep, assignStep } from './api';
 
 /**
- * GitHub #41 — Stop workflow for discontinued clients. Staff (admin/manager/
- * team_member) can stop an in-flight matter with a required reason; it goes
- * `cancelled` and shows the stopped banner. Fresh matter per test.
+ * GitHub #41 — Stop workflow for discontinued clients. An admin can stop an
+ * in-flight matter with a required reason; it goes `cancelled` and shows the
+ * stopped banner. Fresh matter per test.
+ *
+ * GitHub #70 — Stop Workflow & Archive are admin-only. Managers and team
+ * members no longer see the control.
+ *
+ * GitHub #71 — An admin can restart a stopped matter; it resumes from the same
+ * step and returns to `active`. The control is admin-only.
  */
 let taskId: string;
 test.beforeEach(async () => { taskId = await createMatter(); });
@@ -23,22 +29,53 @@ test('admin stops an in-flight matter with a reason', async ({ adminPage }) => {
   }).toPass({ timeout: 15_000 });
 });
 
-test('a team member assigned the active step can stop the matter (#41 + #44 perms)', async ({ teamPage }) => {
+test('a team member never sees the Stop workflow control, even when assigned the active step (#70)', async ({ teamPage }) => {
   const step = await currentStep(taskId);
   await assignStep(taskId, step, process.env.E2E_TEAM_UID!);
 
   await teamPage.goto(`tasks/${taskId}`);
-  await teamPage.getByRole('button', { name: /stop workflow/i }).click();
-  await teamPage.getByPlaceholder(/reason for stopping/i).fill('Client asked to stop.');
-  await teamPage.getByRole('button', { name: /^stop workflow$/i }).last().click();
-
-  await expect(async () => {
-    expect((await getMatter(taskId)).status).toBe('cancelled');
-  }).toPass({ timeout: 15_000 });
+  await expect(teamPage.getByRole('button', { name: 'Steps', exact: true })).toBeVisible();
+  await expect(teamPage.getByRole('button', { name: /stop workflow/i })).toHaveCount(0);
 });
 
 test('client never sees the Stop workflow control', async ({ clientPage }) => {
   await clientPage.goto(`tasks/${taskId}`);
   await expect(clientPage.getByRole('button', { name: 'Steps', exact: true })).toBeVisible();
   await expect(clientPage.getByRole('button', { name: /stop workflow/i })).toHaveCount(0);
+});
+
+test('admin restarts a stopped matter; it resumes from the same step (#71)', async ({ adminPage }) => {
+  const stepBefore = await currentStep(taskId);
+
+  await adminPage.goto(`tasks/${taskId}`);
+  // Stop it first.
+  await adminPage.getByRole('button', { name: /stop workflow/i }).click();
+  await adminPage.getByPlaceholder(/reason for stopping/i).fill('Temporary hold.');
+  await adminPage.getByRole('button', { name: /^stop workflow$/i }).last().click();
+  await expect(adminPage.getByText(/this matter was stopped/i)).toBeVisible();
+
+  // Restart via the banner action → styled confirm dialog.
+  await adminPage.getByRole('button', { name: /restart workflow/i }).click();
+  const dialog = adminPage.getByRole('dialog');
+  await expect(dialog.getByText(/restart this matter\?/i)).toBeVisible();
+  await dialog.getByRole('button', { name: 'Restart' }).click();
+
+  await expect(async () => {
+    const m = await getMatter(taskId);
+    expect(m.status).toBe('active');
+    expect(m.currentStepNumber).toBe(stepBefore);
+  }).toPass({ timeout: 15_000 });
+});
+
+test('a team member never sees the Restart workflow control on a stopped matter (#71)', async ({ adminPage, teamPage }) => {
+  // Admin stops it.
+  await adminPage.goto(`tasks/${taskId}`);
+  await adminPage.getByRole('button', { name: /stop workflow/i }).click();
+  await adminPage.getByPlaceholder(/reason for stopping/i).fill('Held.');
+  await adminPage.getByRole('button', { name: /^stop workflow$/i }).last().click();
+  await expect(adminPage.getByText(/this matter was stopped/i)).toBeVisible();
+
+  await teamPage.goto(`tasks/${taskId}`);
+  await expect(teamPage.getByText(/this matter was stopped/i)).toBeVisible();
+  await expect(teamPage.getByRole('button', { name: /restart workflow/i })).toHaveCount(0);
 });

--- a/Portal/src/api/tasks.ts
+++ b/Portal/src/api/tasks.ts
@@ -68,15 +68,20 @@ export const rejectTask = (id: string, reason: string) =>
   });
 
 /** Stop/cancel an in-flight matter when a client discontinues (GitHub #41).
- *  Staff (admin/manager/team_member). Requires a reason. */
+ *  Admin-only (GitHub #70). Requires a reason. */
 export const stopTask = (id: string, reason: string) =>
   apiFetch<{ success: boolean; status: string }>(`/api/tasks/${id}/stop`, {
     method: 'POST',
     body: JSON.stringify({ reason }),
   });
 
+/** Restart a previously stopped matter, resuming from where it left off (GitHub #71).
+ *  Admin-only. The matter goes back to `active` at its saved current step. */
+export const restartTask = (id: string) =>
+  apiFetch<{ success: boolean; status: string }>(`/api/tasks/${id}/restart`, { method: 'POST' });
+
 /** Archive a matter — non-destructive alternative to delete (admin-only delete).
- *  Staff (admin/manager/team_member). Preserves data; removes it from active lists. */
+ *  Admin-only (GitHub #70). Preserves data; removes it from active lists. */
 export const archiveTask = (id: string) =>
   apiFetch<{ success: boolean; status: string }>(`/api/tasks/${id}/archive`, { method: 'POST' });
 

--- a/Portal/src/pages/tasks/TaskDetailPage.tsx
+++ b/Portal/src/pages/tasks/TaskDetailPage.tsx
@@ -5,14 +5,14 @@ import {
   ArrowLeft, CheckCircle2, Circle, CircleSlash, Loader2, PlayCircle,
   CreditCard, ShieldCheck, ThumbsUp, ThumbsDown, Landmark, GitBranch,
   ListChecks, FileText, IndianRupee, Paperclip, MessageSquare, Briefcase,
-  ChevronRight, ChevronDown, Flame, Ban, Archive,
+  ChevronRight, ChevronDown, Flame, Ban, Archive, RotateCcw,
 } from 'lucide-react';
 import PageShell from '../../components/common/PageShell';
 import { useToast } from '../../components/common/toastContext';
 import DocumentsPanel from '../../components/documents/DocumentsPanel';
 import { getDocuments, openDocument, type TaskDocument } from '../../api/documents';
 import { useAuthStore } from '../../store/authStore';
-import { getTask, advanceTask, assignStep, assignMatter, getTaskEvents, approveTask, rejectTask, stopTask, archiveTask, setTaskUrgent, setStepUrgent, type WorkflowEventInput, type TaskEvent } from '../../api/tasks';
+import { getTask, advanceTask, assignStep, assignMatter, getTaskEvents, approveTask, rejectTask, stopTask, restartTask, archiveTask, setTaskUrgent, setStepUrgent, type WorkflowEventInput, type TaskEvent } from '../../api/tasks';
 import { useConfirm } from '../../components/common/confirmContext';
 import { getAllUsers, displayName, type PortalUser } from '../../api/users';
 import { getWorkflowDefinition, phaseProgress, deriveOwnerType, type WorkflowStepDef, type WorkflowDefinition } from '../../api/workflowDefinitions';
@@ -167,6 +167,26 @@ export default function TaskDetailPage() {
     onError: (err: Error) => toast.error(err.message || 'Could not stop this matter.'),
   });
 
+  // Restart a stopped matter (GitHub #71). Admin-only; resumes from the saved
+  // current step. Confirmed via dialog since it puts the matter back in worklists.
+  const restart = useMutation({
+    mutationFn: () => restartTask(taskId!),
+    onSuccess: () => {
+      toast.success('Matter restarted.');
+      invalidateTaskViews();
+      queryClient.invalidateQueries({ queryKey: ['task-events', taskId] });
+    },
+    onError: (err: Error) => toast.error(err.message || 'Could not restart this matter.'),
+  });
+  const onRestart = async () => {
+    const ok = await confirm({
+      title: 'Restart this matter?',
+      message: 'It will resume from where it was stopped and return to active worklists. Its full history is kept.',
+      confirmLabel: 'Restart',
+    });
+    if (ok) restart.mutate();
+  };
+
   // Archive — non-destructive alternative to delete (staff). Confirmed via dialog.
   const archive = useMutation({
     mutationFn: () => archiveTask(taskId!),
@@ -293,15 +313,27 @@ export default function TaskDetailPage() {
         </div>
       )}
 
-      {/* Stopped/cancelled banner (#41) — terminal state with the reason. */}
+      {/* Stopped/cancelled banner (#41) — reason + admin-only Restart (#71). */}
       {task.status === 'cancelled' && (
         <div className="card p-4 mb-4 border-red-200 bg-red-50/60">
           <div className="flex items-start gap-2.5">
             <Ban className="w-4 h-4 text-red-600 mt-0.5 shrink-0" />
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold text-red-800">This matter was stopped</p>
               {task.cancelledReason && <p className="text-sm text-red-700 mt-0.5">{task.cancelledReason}</p>}
             </div>
+            {role === 'admin' && (
+              <button
+                onClick={onRestart}
+                disabled={restart.isPending}
+                className="btn-secondary shrink-0 inline-flex items-center gap-1.5 text-sm"
+              >
+                {restart.isPending
+                  ? <Loader2 className="w-4 h-4 animate-spin" />
+                  : <RotateCcw className="w-4 h-4" />}
+                Restart workflow
+              </button>
+            )}
           </div>
         </div>
       )}
@@ -316,9 +348,9 @@ export default function TaskDetailPage() {
         </div>
       )}
 
-      {/* Stop workflow (#41) + Archive — staff actions on an in-flight matter.
+      {/* Stop workflow (#41) + Archive — admin-only actions on an in-flight matter (#70).
           Stop = client discontinued (cancelled). Archive = non-destructive hide. */}
-      {isStaff && (task.status === 'active' || task.status === 'pending') && (
+      {role === 'admin' && (task.status === 'active' || task.status === 'pending') && (
         <StopMatterBanner
           open={stopping}
           pending={stop.isPending}
@@ -848,6 +880,8 @@ const EVENT_VERB: Record<string, string> = {
   TASK_APPROVED: 'approved the matter',
   TASK_REJECTED: 'rejected the matter',
   TASK_STOPPED: 'stopped the matter',
+  TASK_RESTARTED: 'restarted the matter',
+  TASK_ARCHIVED: 'archived the matter',
 };
 
 /** Relative time. Module-scope (impure Date.now must not be called in render). */

--- a/backend/src/controllers/tasks.controller.js
+++ b/backend/src/controllers/tasks.controller.js
@@ -455,15 +455,15 @@ export async function rejectTask(req, res) {
 
 // ─── POST /api/tasks/:taskId/stop ──────────────────────────────────────────
 // Stop/cancel an in-flight matter when a client discontinues the service midway
-// (GitHub #41). Available to admin, manager, and team_member. Requires a reason,
-// recorded on the activity thread. The matter moves to `cancelled` (terminal) and
-// its active step is marked cancelled so it leaves worklists. Already-finished
-// matters (completed/cancelled/rejected) can't be stopped.
+// (GitHub #41). Admin-only (GitHub #70). Requires a reason, recorded on the
+// activity thread. The matter moves to `cancelled` (terminal) and its active
+// step is marked cancelled so it leaves worklists. Already-finished matters
+// (completed/cancelled/rejected) can't be stopped.
 export async function stopTask(req, res) {
   try {
     const { role, uid } = req.user;
-    if (role !== 'admin' && role !== 'manager' && role !== 'team_member') {
-      return res.status(403).json({ message: 'Forbidden: staff only' });
+    if (role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden: admin only' });
     }
     const { reason } = req.body; // validated non-empty by taskStopSchema
     const taskRef = db.collection('tasks').doc(req.params.taskId);
@@ -505,6 +505,78 @@ export async function stopTask(req, res) {
   } catch (err) {
     logger.error({ err }, 'stopTask error:');
     res.status(500).json({ message: 'Failed to stop matter' });
+  }
+}
+
+// ─── POST /api/tasks/:taskId/restart ───────────────────────────────────────
+// Restart a previously stopped (`cancelled`) matter (GitHub #71). Admin-only.
+// The matter resumes from where it left off: `currentStepNumber` was preserved
+// on stop, so we re-activate that step and the matter goes back to `active`.
+// The full history is retained — stop/restart are appended as events, nothing is
+// overwritten. Only stopped matters can be restarted; archived matters are out of
+// scope (#71). The ETA clock restarts now, mirroring approve (E13-S02).
+export async function restartTask(req, res) {
+  try {
+    const { role, uid } = req.user;
+    if (role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden: admin only' });
+    }
+    const taskRef = db.collection('tasks').doc(req.params.taskId);
+    const snap = await taskRef.get();
+    if (!snap.exists) return res.status(404).json({ message: 'Matter not found' });
+    const task = snap.data();
+    if (task.status !== 'cancelled') {
+      return res.status(409).json({ message: `Only a stopped matter can be restarted (this one is ${task.status}).` });
+    }
+
+    const now = new Date().toISOString();
+
+    // Restart the ETA clock from the resumed step, best-effort (as in approveTask):
+    // if the pinned definition can't be loaded, resume without due dates rather
+    // than failing the restart.
+    let matterDueAt = null;
+    let stepDueAt = null;
+    try {
+      const compiled = await getCompiledById(task.workflowDefinitionId);
+      if (compiled) {
+        const stepDefs = compiled.definition.steps.filter((s) => s.type !== 'final');
+        const currentDef = stepDefs.find((s) => s.stepNumber === task.currentStepNumber);
+        stepDueAt = addDaysIso(now, etaDaysOf(currentDef));
+        matterDueAt = projectMatterDueAt(stepDefs, task.currentStepNumber, now);
+      }
+    } catch (e) {
+      logger.warn({ err: e?.message }, 'restartTask: ETA stamping skipped (definition unavailable)');
+    }
+
+    const batch = db.batch();
+    // Clear the stopped marker and go back to active.
+    batch.set(taskRef, { status: 'active', cancelledReason: null, updatedAt: now, matterDueAt }, { merge: true });
+    // Re-activate the step that was active when stopped — its assignment and other
+    // fields were preserved (stop only flipped `status` to cancelled).
+    batch.set(
+      taskRef.collection('steps').doc(String(task.currentStepNumber)),
+      { status: 'active', startedAt: now, ...(stepDueAt ? { dueAt: stepDueAt } : {}) },
+      { merge: true },
+    );
+    batch.set(taskRef.collection('events').doc(), {
+      type: 'TASK_RESTARTED',
+      fromStep: task.currentStepNumber,
+      toStep: task.currentStepNumber,
+      comment: null,
+      byUid: uid ?? null,
+      byRole: role ?? null,
+      at: now,
+    });
+    await batch.commit();
+
+    // Notify the matter owner that work has resumed (E07-S01).
+    const ctx = `${task.clientName ?? ''} · ${task.serviceName ?? task.workflowType ?? ''}`;
+    await notify({ recipientUid: task.assignedTo, actorUid: uid, type: 'info', title: 'Matter restarted', message: `${ctx} was restarted and is active again.`, taskId: req.params.taskId });
+
+    res.json({ success: true, status: 'active' });
+  } catch (err) {
+    logger.error({ err }, 'restartTask error:');
+    res.status(500).json({ message: 'Failed to restart matter' });
   }
 }
 
@@ -1355,16 +1427,16 @@ export async function deleteTask(req, res) {
 }
 
 // ─── POST /api/tasks/:taskId/archive ───────────────────────────────────────
-// Archive a matter (staff: admin/manager/team_member). Archiving is the
-// non-destructive alternative to deletion — staff who can't delete (only admin
-// can) can still get a finished/abandoned matter OUT of active worklists without
-// losing its history. Sets status `archived` (terminal); the active step (if any)
-// is closed. Data + documents are preserved; only admin `deleteTask` purges them.
+// Archive a matter (admin-only, GitHub #70). Archiving is the non-destructive
+// alternative to deletion — it gets a finished/abandoned matter OUT of active
+// worklists without losing its history. Sets status `archived` (terminal); the
+// active step (if any) is closed. Data + documents are preserved; only admin
+// `deleteTask` purges them.
 export async function archiveTask(req, res) {
   try {
     const { role, uid } = req.user;
-    if (role !== 'admin' && role !== 'manager' && role !== 'team_member') {
-      return res.status(403).json({ message: 'Forbidden: staff only' });
+    if (role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden: admin only' });
     }
     const taskRef = db.collection('tasks').doc(req.params.taskId);
     const snap = await taskRef.get();

--- a/backend/src/routes/tasks.routes.js
+++ b/backend/src/routes/tasks.routes.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { verifyToken, requireRole } from '../middleware/auth.middleware.js';
 import { validate } from '../middleware/validate.middleware.js';
 import { taskCreateSchema, taskUpdateSchema, taskListQuerySchema, taskTransitionSchema, taskRejectSchema, taskStopSchema, signedUploadUrlSchema, confirmUploadSchema, reviewDocumentSchema } from '../schemas/task.schema.js';
-import { listTasks, getTask, createTask, patchTask, patchStep, transitionTask, deleteTask, listMySteps, listTaskEvents, approveTask, rejectTask, stopTask, archiveTask } from '../controllers/tasks.controller.js';
+import { listTasks, getTask, createTask, patchTask, patchStep, transitionTask, deleteTask, listMySteps, listTaskEvents, approveTask, rejectTask, stopTask, restartTask, archiveTask } from '../controllers/tasks.controller.js';
 import { listDocuments, createSignedUploadUrl, confirmUpload, downloadDocument, reviewDocument } from '../controllers/documents.controller.js';
 
 const router = Router();
@@ -21,10 +21,12 @@ router.post('/:taskId/transition',           validate(taskTransitionSchema), tra
 // Approval chain (E03-S04): admin-only approve / reject of a pending matter.
 router.post('/:taskId/approve',              requireRole('admin'), approveTask);
 router.post('/:taskId/reject',               requireRole('admin'), validate(taskRejectSchema), rejectTask);
-// Stop/cancel an in-flight matter when a client discontinues (#41) — staff.
-router.post('/:taskId/stop',                 requireRole('admin', 'manager', 'team_member'), validate(taskStopSchema), stopTask);
-// Archive a matter (non-destructive; staff) — the alternative to admin-only delete.
-router.post('/:taskId/archive',              requireRole('admin', 'manager', 'team_member'), archiveTask);
+// Stop/cancel an in-flight matter when a client discontinues (#41) — admin-only (#70).
+router.post('/:taskId/stop',                 requireRole('admin'), validate(taskStopSchema), stopTask);
+// Restart a previously stopped matter, resuming from where it left off (#71) — admin-only.
+router.post('/:taskId/restart',              requireRole('admin'), restartTask);
+// Archive a matter (non-destructive) — admin-only (#70); the alternative to admin-only delete.
+router.post('/:taskId/archive',              requireRole('admin'), archiveTask);
 
 // Document cycle (E-05). Upload (signed URL → confirm), list, download, review.
 // Clients may upload/confirm/list/download on their OWN matter; only staff review.


### PR DESCRIPTION
## Summary
Two related matter-lifecycle changes, both gated to **admins only**.

### #70 — Restrict Stop Workflow & Archive to admins
- **Portal:** the Stop/Archive banner renders only for `role === 'admin'` (previously any staff). Managers and team members no longer see either action.
- **Backend:** `/stop` and `/archive` routes **and** their controllers are admin-only (defense in depth).
- Workflow execution logic untouched.

### #71 — Restart Workflow for stopped matters (admin-only)
- **Backend:** new `POST /api/tasks/:taskId/restart` (admin-only). Only a `cancelled` matter can be restarted. It resumes from the preserved `currentStepNumber`: the step is re-activated with its assignment intact, status returns to `active`, the ETA clock restarts, and a `TASK_RESTARTED` event is appended. **Full history retained** — stop/restart are events, nothing is overwritten. Archived matters are out of scope.
- **Portal:** admin-only "Restart workflow" button in the stopped banner with a styled confirm; `restartTask` API + `TASK_RESTARTED`/`TASK_ARCHIVED` event labels.

## Tests
`stop-workflow.spec.ts` updated:
- team member / client can't see Stop
- admin can Restart a stopped matter (resumes the same step)
- team member can't see Restart

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)