### PR TITLE
feat(analytics): install GTM alongside gtag.js, make prerender snapsh…

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager - DO NOT REMOVE -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K77S87GP');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -13,8 +20,24 @@
     <link rel="dns-prefetch" href="https://legalterminus.com" />
     <link rel="dns-prefetch" href="https://images.unsplash.com" />
     <link rel="dns-prefetch" href="https://corpbiz.io" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6PM135PT7Y"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-6PM135PT7Y');
+      // Google Ads shares the one tag above — a second destination, not a second loader.
+      gtag('config', 'AW-16532822973');
+    </script>
   </head>
   <body>
+    <!-- Google Tag Manager - DO NOT REMOVE -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K77S87GP"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager -->
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/Frontend/scripts/gen-sitemap.mjs
+++ b/Frontend/scripts/gen-sitemap.mjs
@@ -12,12 +12,12 @@
  */
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SITE = 'https://legalterminus.com';
 
-const { SEO_META } = await import(path.join(ROOT, 'src/data/seoMeta.js'));
+const { SEO_META } = await import(pathToFileURL(path.join(ROOT, 'src/data/seoMeta.js')).href);
 
 const indexable = Object.entries(SEO_META)
   .filter(([route, meta]) => !meta.noindex && !meta.canonicalPath && !route.includes(':'))

--- a/Frontend/scripts/prerender.mjs
+++ b/Frontend/scripts/prerender.mjs
@@ -20,7 +20,7 @@ import { chromium } from '@playwright/test';
 import { preview } from 'vite';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -31,7 +31,7 @@ const CONCURRENCY = 4;             // parallel pages; keeps a full run to ~1-2 m
 
 /** Routes to snapshot: everything in the SEO map except noindex + dynamic ones. */
 async function indexableRoutes() {
-  const { SEO_META } = await import(path.join(ROOT, 'src/data/seoMeta.js'));
+  const { SEO_META } = await import(pathToFileURL(path.join(ROOT, 'src/data/seoMeta.js')).href);
   return Object.entries(SEO_META)
     .filter(([route, meta]) => !meta.noindex && !route.includes(':'))
     .map(([route]) => route);
@@ -81,6 +81,18 @@ async function snapshot(context, route) {
       const titles = [...document.head.querySelectorAll('title')];
       titles.slice(1).forEach((el) => el.remove());
       if (titles[0]) titles[0].textContent = current;
+
+      // GTM's official snippet self-installs: its inline bootstrap runs synchronously
+      // on load and does document.createElement('script') + insertBefore to add its
+      // own <script src=gtm.js> — a DOM mutation the network abort below can't stop.
+      // Left in place, this injected element would be captured into the static
+      // snapshot, and the original inline bootstrap (which stays in the HTML
+      // unchanged) would inject a SECOND copy when a real visitor's browser runs it.
+      // The original bootstrap has no `src` attribute (it's inline code), so this
+      // selector can only ever match the dynamically-injected duplicate.
+      document.head
+        .querySelectorAll('script[src^="https://www.googletagmanager.com/gtm.js"]')
+        .forEach((el) => el.remove());
     });
 
     const html = await page.content();
@@ -114,6 +126,21 @@ async function main() {
     // Identify as a bot so any analytics/consent scripts can opt out of the snapshot.
     userAgent: 'Mozilla/5.0 (compatible; LegalTerminusPrerender/1.0)',
   });
+
+  // Never let the Google tag (or GTM) run during a snapshot. Prerendering visits
+  // every indexable route in a real browser, so without this each build would
+  // register a live page_view/container load for every route — all from the
+  // local preview server, polluting the property with traffic no human generated.
+  // Aborting the request also keeps gtag's injected runtime out of the captured
+  // HTML; gtag's <script> tag itself still ships as static markup, because it
+  // lives in index.html and nothing here removes it. GTM's bootstrap is
+  // different — it's self-injecting, so this abort alone doesn't stop it from
+  // adding its own <script> element to the DOM; that's handled separately by the
+  // cleanup in page.evaluate() below (see the comment there).
+  await context.route(
+    /(googletagmanager\.com|google-analytics\.com|analytics\.google\.com)/,
+    (route) => route.abort(),
+  );
 
   const results = [];
   const queue = [...routes];
@@ -159,6 +186,12 @@ async function main() {
         const titles = [...document.head.querySelectorAll('title')];
         titles.slice(1).forEach((el) => el.remove());
         if (titles[0]) titles[0].textContent = current;
+
+        // Same GTM self-injection cleanup as the route snapshot above — see the
+        // comment there for why this selector only ever matches the duplicate.
+        document.head
+          .querySelectorAll('script[src^="https://www.googletagmanager.com/gtm.js"]')
+          .forEach((el) => el.remove());
       });
       await writeFile(path.join(DIST, '404.html'), await page.content(), 'utf8');
       console.log('[prerender] 404.html written');


### PR DESCRIPTION
…ot-safe

- Add the official GTM bootstrap (GTM-K77S87GP) to Frontend/index.html: script as high as possible in <head>, noscript iframe right after <body>. Existing gtag.js (GA4 G-6PM135PT7Y + Google Ads AW-16532822973) is untouched.
- prerender.mjs: GTM's snippet self-installs by injecting its own <script src=gtm.js> via document.createElement/insertBefore. The existing network abort (already covering googletagmanager.com for gtag) stops that request from firing during the build's headless crawl, but not the DOM mutation itself — so the injected element was getting baked into the static snapshot, and the untouched inline bootstrap would inject a second copy when a real visitor's browser ran it. Added a DOM-level cleanup, alongside the existing head-tag dedupe, that strips the dynamically-injected duplicate before each snapshot is written (route pages + 404.html). The selector only ever matches the injected copy, never the real snippet, since the original bootstrap has no `src` attribute.
- Fix ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows: wrap the dynamic import() path for seoMeta.js in pathToFileURL() in both prerender.mjs and gen-sitemap.mjs, matching Node's requirement for a file:// URL.